### PR TITLE
Make runnable on GTK 3.14

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,13 +27,13 @@ gameModeSwitch = builder.get_object("gameModeSwitch")
 
 universalApplyButton.modify_bg(
     Gtk.StateFlags.NORMAL,
-    Gdk.Color.parse('#4884cb').color)
+    Gdk.Color.parse('#4884cb')[1])
 universalApplyButton.modify_bg(
     Gtk.StateFlags.PRELIGHT,
-    Gdk.Color.parse('#5294E2').color)
+    Gdk.Color.parse('#5294E2')[1])
 universalApplyButton.modify_bg(
     Gtk.StateFlags.ACTIVE,
-    Gdk.Color.parse('#454A57').color)
+    Gdk.Color.parse('#454A57')[1])
 
 devicesList = []
 

--- a/ui.glade
+++ b/ui.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.18"/>
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkAdjustment" id="brightnessAdjustment">
     <property name="upper">100</property>
     <property name="value">100</property>
@@ -58,7 +58,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="transition_type">slide-left-right</property>
-                <property name="interpolate_size">True</property>
                 <child>
                   <object class="GtkBox" id="dpiBox">
                     <property name="visible">True</property>


### PR DESCRIPTION
It would appear the color tuple has become a `namedtuple` later on, which is nice, but 3.14 doesn't do it.

Not sure what `interpolate_size` does exactly, but this is required.

The rationale for this is that it would be nice to run on Debian Stable, especially if the fix is this minor.

Furthermore, I own a Steam Machine with SteamOS, essentialy Debian Stable, onto which I installed the prerequisite packages to run `razer-drivers` and it's kind of a bummer to not be able to use them for anything. Chances are slightly above 0 that this is interesting to someone beside me ;)

Unfortunately I don't see the device so I can't be a 100% sure nothing broke down...

Please advise.

Thanks!
