### PR TITLE
Add ability to toggle fn lock/fix game mode not hiding

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,8 @@ refreshDevicesButton=builder.get_object('refreshDevicesButton')
 
 keyboardBox = builder.get_object("keyboardBox")
 gameModeSwitch = builder.get_object("gameModeSwitch")
+fnLockSwitch = builder.get_object("fnLockSwitch")
+fnLockLabel = builder.get_object("fnLockLabel")
 
 universalApplyButton.modify_bg(
     Gtk.StateFlags.NORMAL,
@@ -78,12 +80,14 @@ def updateDevicesConnected():
         keyboardBox.hide()
         noDevicesLabel.hide()
         gameModeSwitch.set_sensitive(True)
+        fnLockSwitch.set_sensitive(True)
         universalApplyButton.set_sensitive(True)
     else:
         print("no devices")
         mainBox.hide()
         noDevicesLabel.show()
         gameModeSwitch.set_sensitive(False)
+        fnLockSwitch.set_sensitive(False)
         universalApplyButton.set_sensitive(False)
 
 def refreshDevices():
@@ -234,6 +238,13 @@ def refreshFxList():
     else:
         gameModeIcon.hide()
         gameModeSwitch.hide()
+
+    if myrazerkb.hasFnToggle:
+        fnLockLabel.show()
+        fnLockSwitch.show()
+    else:
+        fnLockLabel.hide()
+        fnLockSwitch.hide()
 
     # selective hiding of switcher buttons
     stackButtons = mainStackSwitcherButtons.get_children()
@@ -575,6 +586,9 @@ class Handler:
             enableFXwSettings(currentFX)
         else:
             myrazerkb.enableFX(currentFX)
+
+    def on_fnLockSwitch_state_set(self, *args):
+        myrazerkb.setFnLock(not fnLockSwitch.get_state())
 
     def on_gameModeSwitch_state_set(self, *args):
         myrazerkb.toggleGameMode()

--- a/ui.glade
+++ b/ui.glade
@@ -1216,6 +1216,7 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="no_show_all">True</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkButton" id="refreshDevicesButton">
@@ -1258,6 +1259,31 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="fnLockLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Fn-Lock</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="fnLockSwitch">
+                <property name="can_focus">True</property>
+                <property name="valign">center</property>
+                <signal name="state-set" handler="on_fnLockSwitch_state_set" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
My blade stealth doesn't support game mode but when I open the application, the switch still shows. If I select my device in the dropdown it hides like it's supposed to. I made the container of the switch no_show_all and that seemed to fix the problem.

In my device folder (`/sys/bus/hid/drivers/razerkbd/<DEVICE ID>/`) there is a file called `fn_toggle`. Writing a 1 or 0 to this file changes the behavior of the F keys (like fn lock, which my keyboard does not have). I added a switch to the right of the game mode switch that only shows if the selected device has a `fn_toggle` file.

Unfortunately there is nothing in the razer-drivers python client for this fn lock functionality, so I opted to just write directly to `fn_toggle`. Furthermore, `fn_toggle` is write only, so the switch may not accurately show if 'fn-lock' is on/off.

I'm not sure if this feature has enough demand to justify these somewhat sketchy additions, but please let me know what you think!