### PR TITLE
Fix the application for a symlinked main.py script

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import custom_profiles
 import listboxHelper
 import custom_kb_builder
 
-EXEC_FOLDER = os.path.realpath(os.path.dirname(__file__)) + "/"
+EXEC_FOLDER = os.path.dirname(os.path.realpath(__file__)) + "/"
 builder = Gtk.Builder()
 builder.add_from_file(EXEC_FOLDER + "ui.glade")
 HOME = os.environ.get('HOME')


### PR DESCRIPTION
This resolves the symlink first before cutting off the filename. 
You can reproduce the problem by doing `ln -s /usr/share/razercommander/main.py /tmp/razercommander && /tmp/razercommander`.