### PR TITLE
Added exception handling to skip over unsupported devices

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ try:
     import device
     print('Device logic loaded, deamon is alive')
 except:
-    print('ERROR: the daemon is not responding!\nTry running `killall razer-service && razer-service` or rebooting. If this doesn\'t work, please fill an issue!')
+    print('ERROR: the daemon is not responding!\nTry running `killall razer-daemon && razer-daemon` or rebooting. If this doesn\'t work, please fill an issue!')
     exit(1)
 import custom_keyboard as CustomKb
 import custom_profiles
@@ -41,8 +41,12 @@ def initDevices():
     global devicesList
     devicesList = []
     for dev in device.devlist:
-        newdev = device.Device(dev)
-        devicesList.append(newdev)
+        try:
+            newdev = device.Device(dev)
+            devicesList.append(newdev)
+        except:
+            print('Skipping device: ' + dev.name)
+            pass
 
 def fillDevicesList():
     if len(devicesList) > 0:


### PR DESCRIPTION
Fixed an error message to not say 'service' and added exception handling to skip over unsupported devices.

I have a Tartarus Chroma that for some reason seems to be crashing the application when it starts up. [See this issue for more detail of why I made this change](https://github.com/GabMus/razerCommander/issues/35).